### PR TITLE
add: docker-compose.yml & Dockerfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
       run: |
         sudo service ssh start
         echo 'PermitRootLogin yes' | sudo tee -a /etc/ssh/sshd_config
+        echo 'Port 2222' | sudo tee -a /etc/ssh/sshd_config
         sudo service ssh restart
 
     - name: Setup user for SSH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:latest
+
+RUN apt-get update
+RUN apt-get install -y openssh-server sysstat util-linux coreutils
+RUN useradd -m explorer && echo "explorer:explorer" | chpasswd
+RUN mkdir /var/run/sshd
+
+EXPOSE 2222
+
+CMD ["/usr/sbin/sshd", "-D", "-p", "2222"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+services:
+  db:
+    container_name: de-psql
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_DB: explorer
+      POSTGRES_USER: explorer
+      POSTGRES_PASSWORD: explorer
+      POSTGRES_SHARED_PRELOAD_LIBRARIES: 'pg_stat_statements'
+    ports:
+      - 5432:5432
+  ssh:
+    container_name: de-ssh
+    build: .
+    restart: always
+    ports:
+      - 2222:2222

--- a/src/main/java/jp/ac/databaseexplorer/async/main/AsyncDataCollectionService.java
+++ b/src/main/java/jp/ac/databaseexplorer/async/main/AsyncDataCollectionService.java
@@ -29,7 +29,7 @@ public class AsyncDataCollectionService {
    */
   @Scheduled(fixedRateString = "${db.data.async.collection.interval}")
   public void start() throws ApplicationException {
-//    visualizeRepository.start();
+    visualizeRepository.start();
     // analyzeRepository.start();
     // suggestRepository.start();
   }

--- a/src/main/java/jp/ac/databaseexplorer/common/component/os/SshUtil.java
+++ b/src/main/java/jp/ac/databaseexplorer/common/component/os/SshUtil.java
@@ -33,6 +33,7 @@ public class SshUtil {
       @Value("${os.data.async.collection.auth}")        String auth,
       @Value("${os.data.async.collection.username}")    String username,
       @Value("${os.data.async.collection.address}")     String host,
+      @Value("${os.data.async.collection.port}")        Integer port,
       @Value("${os.data.async.collection.password}")    String password,
       @Value("${os.data.async.collection.keyfile}")     String keyfile,
       @Value("${os.data.async.collection.passphrase}")  String passphrase,
@@ -42,14 +43,14 @@ public class SshUtil {
       JSch jsch = new JSch();
       switch (auth) {
         case "password" -> {
-          this.session = jsch.getSession(username, host);
+          this.session = jsch.getSession(username, host, port);
           this.session.setPassword(password);
           this.session.setConfig("StrictHostKeyChecking", "no");
         }
         case "publickey" -> {
           jsch.addIdentity(keyfile, passphrase);
           jsch.setKnownHosts(known_hosts);
-          this.session = jsch.getSession(username, host);
+          this.session = jsch.getSession(username, host, port);
         }
         default -> throw new SystemException("", "", new Exception());
       }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,6 +21,7 @@ os.kind=linux
 os.data.async.collection.auth=password
 os.data.async.collection.username=explorer
 os.data.async.collection.address=localhost
+os.data.async.collection.port=2222
 os.data.async.collection.password=explorer
 os.data.async.collection.keyfile=~/.ssh/keyfile
 os.data.async.collection.passphrase=explorer


### PR DESCRIPTION
ローカルで開発しやすいように、Dockerコンテナで監視対象のDBを動かせるようにしてみました。
（自分でDockerfileを書くことがあまりないので、ご指摘等あればお願いします！）

# 手順
1. `databaseexplorer`直下でコンテナ立ち上げ
   ```bash
   $ docker-compose up -d --build
   ```
2. SSH接続できるか確認
   ```bash
   $ ssh explorer@localhost -p 2222
   ```
3. ポスグレが動いてるか確認（ついでにpg_stat_statementを起動）
   ```bash
   $ psql -h localhost -p 5432 -U explorer -d explorer
   # CREATE EXTENSION pg_stat_statements;
   ```

# 注意点
- ポスグレをローカルで既に動かしている場合、ポートが重複します。
- SSHは2222ポートを使ってます。