### PR TITLE
平均クエリ時間取得ジョブを再度修正

### DIFF
--- a/src/main/java/jp/ac/databaseexplorer/async/repository/AvgExecTimeRepository.java
+++ b/src/main/java/jp/ac/databaseexplorer/async/repository/AvgExecTimeRepository.java
@@ -11,10 +11,10 @@ import java.util.List;
 public interface AvgExecTimeRepository extends JpaRepository<AvgExecTime, Short> {
   @Query(value = "SELECT " +
       "CASE " +
-      "WHEN query LIKE 'SELECT%' THEN 1 " +
-      "WHEN query LIKE 'INSERT%' THEN 2 " +
-      "WHEN query LIKE 'UPDATE%' THEN 3 " +
-      "WHEN query LIKE 'DELETE%' THEN 4 " +
+      "WHEN query ILIKE '%INSERT%' THEN 2 " +
+      "WHEN query ILIKE '%UPDATE%' THEN 3 " +
+      "WHEN query ILIKE '%DELETE%' THEN 4 " +
+      "WHEN query ILIKE '%SELECT%' THEN 1 " +
       "END AS kind, " +
       "SUM(calls) AS calls, " +
       "SUM(total_exec_time) AS total_exec_time " +


### PR DESCRIPTION
- 修正の誤りを直した（`ILIKE`を使う）
- SQLの文頭じゃなくてもキーワードを検出するようにした
- `SELECT`文は最後に検出するようにした

👇こんなケースもあるかなと思い。分類の限界はどのみちあるんですが、、
```sql
WITH
  pre AS (
    SELECT col1
    FROM table1
  )
INSERT INTO table2
SELECT *
FROM pre
```